### PR TITLE
URL decode parameter values for proper save

### DIFF
--- a/Sitecore.ClientExtensions/Sitecore.ClientExtensions/Pipelines/Renderings/SaveRenderingPropertiesFieldEditor/SetValues.cs
+++ b/Sitecore.ClientExtensions/Sitecore.ClientExtensions/Pipelines/Renderings/SaveRenderingPropertiesFieldEditor/SetValues.cs
@@ -32,7 +32,7 @@ namespace Sitecore.ClientExtensions.Pipelines.Renderings.SaveRenderingProperties
                 foreach (var key in currentParams.Parameters.AllKeys)
                 {
                     var name = key;
-                    var value = currentParams[key];
+                    var value = HttpUtility.UrlDecode(HttpUtility.UrlDecode(currentParams[key]));
                     SetValue(renderingDef, parameters, name, value);
                 }
             }


### PR DESCRIPTION
Hello,

I'm currently using v1.0.6 of the CC.Sitecore.ClientExtensions NuGet package and noticed a bug where rendering parameters with the raw value of an ID are not being saved correctly.

To reproduce:

1. Create rendering parameters and add two fields A and B, both using the Droptree field type.
2. Create rendering and assign the parameters from step 1 to the rendering.
3. Open core database and create the custom experience button.  **Make sure that only field A is being edited via the button.  Field B should not show up in the dialog window.**
4. Assign the custom experience button from step 3 to the rendering you created in step 2.
5. Add rendering from step 2 to a page and make sure field B has a value.
6. Using the custom experience button you created in step 3, change and/or set the value of field A.
7. You should now see an incorrect value for field B when you edit component properties.  The value, which should be an ID, is now double URL encoded.

Let me know if you have any further questions, I can send a video demonstrating these steps if you'd like.

The fix in this branch is to simply URL decode the parameter values.